### PR TITLE
Upgrades BraintreeDropIn dependency to 7.4

### DIFF
--- a/ios/RNBraintreeDropIn.podspec
+++ b/ios/RNBraintreeDropIn.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency "BraintreeDropIn", '~> 6.0'
+  s.dependency "BraintreeDropIn", '~> 7.4'
 end


### PR DESCRIPTION
Tested and works with iOS 13 and dark mode.
(Haven't tested 3ds.)

Should fix #18 